### PR TITLE
Prebuild Action Docker image and host on ghcr.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM python:3.8.18-slim-bullseye AS builder
+
+LABEL org.opencontainers.image.source=https://github.com/Atom-Learning/bigquery-upload-action
+LABEL org.opencontainers.image.description="This Github action can be used to upload samples to BigQuery table."
+LABEL org.opencontainers.image.licenses=MIT
+
 ADD . /app
 WORKDIR /app
 
-RUN apt-get update
-RUN apt-get install -y g++
 # We are installing a dependency here directly into our app source dir
 RUN pip install --target=/app -r plugin_scripts/requirements.lock
 ENV PYTHONPATH /app

--- a/action.yml
+++ b/action.yml
@@ -23,4 +23,4 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/atom-learning/bigquery-upload-action:v0.5.1'


### PR DESCRIPTION
Using this Action currently uses ~30s of runtime on each run to download and build the image. This PR switches the Action to use a [public prebuilt Docker image](https://github.com/Atom-Learning/bigquery-upload-action/pkgs/container/bigquery-upload-action), hosted on ghcr.io, instead. It also removes the `g++` dependency as it doesn't seem to be required any more. This brings the per-run time down to ~5s for downloading the image.

Once this is merged, I'll tag a new v0.5.1 release.