### PR TITLE
bump deprecated artifact version to v4

### DIFF
--- a/.github/actions/install-dependencies/action.sh
+++ b/.github/actions/install-dependencies/action.sh
@@ -5,10 +5,10 @@ python -m pip install --upgrade pip
 
 if [[ "${INSTALL_REQUIREMENTS}" == "true"  ]]; then
   echo "Installing code requirements"
-  pip install -r plugin_scripts/requirements.lock
+  pip install --no-cache-dir -r plugin_scripts/requirements.lock
 fi
 
 if [[ "${INSTALL_TEST_REQUIREMENTS}" == "true"  ]]; then
   echo "Installing test requirements"
-  pip install -r requirements-test.txt
+  pip install --no-cache-dir -r requirements-test.txt
 fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
       branches: ["main"]
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.11"
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: pytest --cov deploy tests/test_insert_rows.py --cov-report xml:coverage-${{ env.PYTHON_VERSION }}.xml --junitxml=test-results-${{ env.PYTHON_VERSION }}.xml
 
       - name: Upload pytest test results artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-results-${{ env.PYTHON_VERSION }}
           path: test-results-${{ env.PYTHON_VERSION }}.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   test:
     name: Pytest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         # Versions available: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # Versions available: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-        python-version: [ "3.6.7", "3.7.1", "3.8.0", "3.9.0", "3.10.0" ]
+        python-version: [ "3.9.0", "3.10.0" ]
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # Versions available: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-        python-version: [ "3.9.0", "3.10.0", "3.11.0" ]
+        python-version: [ "3.9.0", "3.10.0", "3.11.11" ]
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   test:
     name: Pytest
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # Versions available: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
+        # Versions available: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+        python-version: [ "3.6.7", "3.7.1", "3.8.0", "3.9.0", "3.10.0" ]
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ on:
   push:
       branches: ["main"]
 
-env:
-  PYTHON_VERSION: "3.10"
-
 jobs:
   test:
     name: Pytest
@@ -14,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # Versions available: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-        python-version: [ "3.9.0", "3.10.0" ]
+        python-version: [ "3.9.0", "3.10.0", "3.11.0" ]
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ always() }}
 
       - name: Upload coverage results artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-coverage-${{ env.PYTHON_VERSION }}
           path: coverage-${{ env.PYTHON_VERSION }}.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
         with:
@@ -27,20 +27,22 @@ jobs:
           test-requirements: "true"
 
       - name: Run pytest
-        run: pytest --cov deploy tests/test_insert_rows.py --cov-report xml:coverage-${{ env.PYTHON_VERSION }}.xml --junitxml=test-results-${{ env.PYTHON_VERSION }}.xml
+        run: pytest --cov deploy tests/test_insert_rows.py --cov-report xml:coverage-${{ matrix.python-version }}.xml --junitxml=test-results-${{ matrix.python-version }}.xml
 
       - name: Upload pytest test results artifact
         uses: actions/upload-artifact@v4
         with:
-          name: pytest-results-${{ env.PYTHON_VERSION }}
-          path: test-results-${{ env.PYTHON_VERSION }}.xml
+          name: pytest-results-${{ matrix.python-version }}
+          path: test-results-${{ matrix.python-version }}.xml
+          retention-days: 3
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
 
       - name: Upload coverage results artifact
         uses: actions/upload-artifact@v4
         with:
-          name: pytest-coverage-${{ env.PYTHON_VERSION }}
-          path: coverage-${{ env.PYTHON_VERSION }}.xml
+          name: pytest-coverage-${{ matrix.python-version }}
+          path: coverage-${{ matrix.python-version }}.xml
+          retention-days: 3
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v4] - 2025-01-10
+
+### Added
+
+ - CI: Fix matrix actions workflow
+ - CI: Disable pip cache for installations
+
+### Updated
+
+ - CI: Deprecated `actions/upload-artifact` version
+ - CI: (3.8 -> 3.11)
+ - Docker image - Python version (3.8 -> 3.11)
+
+### Removed
+
+ - CI: Python matrix test versions 3.6 & 3.7
+
 ## [v3] - 2021-12-18
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.18-slim-bullseye AS builder
+FROM python:3.11.0-slim-bullseye AS builder
 
 LABEL org.opencontainers.image.source=https://github.com/Atom-Learning/bigquery-upload-action
 LABEL org.opencontainers.image.description="This Github action can be used to upload samples to BigQuery table."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.0-slim-bullseye AS builder
+FROM python:3.11.11-slim-bookworm AS builder
 
 LABEL org.opencontainers.image.source=https://github.com/Atom-Learning/bigquery-upload-action
 LABEL org.opencontainers.image.description="This Github action can be used to upload samples to BigQuery table."


### PR DESCRIPTION
- Remove deprecated artifact upload action (bump to version 4)
- Limit tested Python versions to 3.9 & 3.10
- Fix matrix syntax for testing
- Limit retention of tests to 3 days
- Disable cache-dir for pip installations for CI
- Bump to version 3.11 in Actions CI & Docker base image